### PR TITLE
fixed map quotes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "disk_size_gb" {
 
 variable "tags" {
   description = "The tags to associate with your managed disk."
-  type        = "map"
+  type        = map
 
   default = {
     tag1 = ""


### PR DESCRIPTION
Using the module, I got the following error:

```
Error: Invalid quoted type constraints
│
│   on .terraform\modules\manageddisk\variables.tf line 48, in variable "tags":
│   48:   type        = "map"
│
│ Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will
│ be removed in a future version of Terraform. Remove the quotes around "map" and write map(string) instead to
│ explicitly indicate that the map elements are strings.
```'

I fixed it by removing quotes on map type.